### PR TITLE
Upgrade @libsql/client version for compatibility with Bun 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@elysiajs/html": "^0.5.2",
-    "@libsql/client": "^0.3.0",
+    "@libsql/client": "^0.3.3",
     "drizzle-orm": "^0.27.2",
     "elysia": "^0.5.22"
   }


### PR DESCRIPTION
Bun 1.0.0 breaks compatibility with @libsql/client. @libsql/client version 0.3.3 works here, see 
[here](https://github.com/libsql/isomorphic-ts/commit/eb02937420344359e2c084e4256d74fb9e1f6d3a) for more context.
