### PR TITLE
chore: refactor hasAnyUnresolvedPromiseChildren

### DIFF
--- a/packages/beth-stack/package.json
+++ b/packages/beth-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beth-stack",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "type": "module",
   "bin": "./dist/cli/index.js",
   "exports": {

--- a/packages/beth-stack/src/jsx/suspense.tsx
+++ b/packages/beth-stack/src/jsx/suspense.tsx
@@ -22,6 +22,10 @@ export const swapScript = `
   </script>
 `;
 
+function isNotFulfilled(child: Promise<unknown>) {
+  return Bun.peek.status(child) !== "fulfilled";
+}
+
 export async function Suspense({
   fallback,
   children,
@@ -32,10 +36,7 @@ export async function Suspense({
   if (!Array.isArray(children))
     throw new Error("children isnt array (shouldnt be possible)");
 
-  const hasAnyUnresolvedPromiseChildren = children.reduce(
-    (acc, child) => acc || Bun.peek.status(child) !== "fulfilled",
-    false,
-  );
+  const hasAnyUnresolvedPromiseChildren = children.some(isNotFulfilled);
 
   if (!hasAnyUnresolvedPromiseChildren) {
     return children.join("");


### PR DESCRIPTION
I improved the speed of checking for unfulfilled promise children by using [Array.some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) which stops at the first true value.