### PR TITLE
Updated -> beth-stack - >cli : Live relaod console log for readability.

### DIFF
--- a/packages/beth-stack/src/cli/index.ts
+++ b/packages/beth-stack/src/cli/index.ts
@@ -34,5 +34,5 @@ const app = new Elysia()
   .listen(port);
 
 console.log(
-  `🦊 Livereload running ${app.server?.hostname}:${app.server?.port}`,
+  `🦊 Live reload running: https://${app.server?.hostname}:${app.server?.port}`,
 );


### PR DESCRIPTION
I made a minor quality of life improvement to the console log statement for Livereload. Changed the message format for better readability.

Original: `🦊 Livereload running ${app.server?.hostname}:${app.server?.port}`
Updated: `🦊 Live reload running: https://${app.server?.hostname}:${app.server?.port}`

Please review and let me know if this aligns with the project's conventions.
